### PR TITLE
Relation font: Computer Modern -> Latin Modern when loading lmodern package

### DIFF
--- a/japanese-otf-uptex/sty/otf.sty
+++ b/japanese-otf-uptex/sty/otf.sty
@@ -11,6 +11,7 @@
 \newif\if@newglyph \@newglyphfalse
 \newif\if@otf@uplatex \@otf@uplatexfalse
 \newif\if@otf@autodetect \@otf@autodetectfalse
+\newif\if@otf@lmodern \@otf@lmodernfalse
 \newif\if@otf@scale \@otf@scalefalse
 \newif\if@jsclasses \@jsclassesfalse
 
@@ -24,6 +25,7 @@
 \DeclareOption{burasage}{\@burasagetrue}
 \DeclareOption{uplatex}{\@otf@uplatextrue}
 \DeclareOption{autodetect-engine}{\@otf@autodetecttrue}
+\DeclareOption{lmodern}{\@otf@lmoderntrue}
 \DeclareOption{jis2004}{\@newglyphtrue}
 \DeclareOption*{\otfpkg@setkey}
 \def\otfpkg@setkey{\expandafter\otfpkg@setkey@a\expandafter{\CurrentOption}}
@@ -33,6 +35,7 @@
 \def\otf@JYn{\if@otf@uplatex JY2\else JY1\fi}
 \def\otf@JTn{\if@otf@uplatex JT2\else JT1\fi}
 \def\otf@OTorT{\if@otf@uplatex T\else OT\fi}
+\def\otf@cmorlm@{\if@otf@lmodern l\else c\fi m}
 \def\otf@pfx@{\if@otf@uplatex up\else \fi}
 \def\brsg@pfx@{\if@burasage brsg\else\fi}
 \def\nlck@sfx@{\if@newglyph n\else\fi}
@@ -66,6 +69,10 @@
 		\@otf@uplatexfalse
 	\fi
 \fi
+% Latin Modern
+\@ifpackageloaded{lmodern}{%
+	\PackageInfo{otf}{Relation font: Latin Modern}
+	\@otf@lmoderntrue}\relax
 %user interface
 %force catcode of \" be 12
 \count@\catcode`\"
@@ -293,20 +300,20 @@
 	\DeclareKanjiFamily{\otf@JTn}{hmc}{}
 	\DeclareKanjiFamily{\otf@JYn}{hgt}{}
 	\DeclareKanjiFamily{\otf@JTn}{hgt}{}
-	\DeclareRelationFont{\otf@JYn}{hmc}{m}{}{\otf@OTorT1}{cmr}{m}{}
-	\DeclareRelationFont{\otf@JTn}{hmc}{m}{}{\otf@OTorT1}{cmr}{m}{}
-	\DeclareRelationFont{\otf@JYn}{hmc}{bx}{}{\otf@OTorT1}{cmr}{bx}{}
-	\DeclareRelationFont{\otf@JTn}{hmc}{bx}{}{\otf@OTorT1}{cmr}{bx}{}
+	\DeclareRelationFont{\otf@JYn}{hmc}{m}{}{\otf@OTorT1}{\otf@cmorlm@ r}{m}{}
+	\DeclareRelationFont{\otf@JTn}{hmc}{m}{}{\otf@OTorT1}{\otf@cmorlm@ r}{m}{}
+	\DeclareRelationFont{\otf@JYn}{hmc}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
+	\DeclareRelationFont{\otf@JTn}{hmc}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
 	\if@deluxe
-		\DeclareRelationFont{\otf@JYn}{hgt}{m}{}{\otf@OTorT1}{cmss}{m}{}
-		\DeclareRelationFont{\otf@JTn}{hgt}{m}{}{\otf@OTorT1}{cmss}{m}{}
-		\DeclareRelationFont{\otf@JYn}{hgt}{bx}{}{\otf@OTorT1}{cmss}{bx}{}
-		\DeclareRelationFont{\otf@JTn}{hgt}{bx}{}{\otf@OTorT1}{cmss}{bx}{}
+		\DeclareRelationFont{\otf@JYn}{hgt}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
+		\DeclareRelationFont{\otf@JTn}{hgt}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
+		\DeclareRelationFont{\otf@JYn}{hgt}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{bx}{}
+		\DeclareRelationFont{\otf@JTn}{hgt}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{bx}{}
 	\else
-		\DeclareRelationFont{\otf@JYn}{hgt}{m}{}{\otf@OTorT1}{cmr}{bx}{}
-		\DeclareRelationFont{\otf@JTn}{hgt}{m}{}{\otf@OTorT1}{cmr}{bx}{}
-		\DeclareRelationFont{\otf@JYn}{hgt}{bx}{}{\otf@OTorT1}{cmr}{bx}{}
-		\DeclareRelationFont{\otf@JTn}{hgt}{bx}{}{\otf@OTorT1}{cmr}{bx}{}
+		\DeclareRelationFont{\otf@JYn}{hgt}{m}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
+		\DeclareRelationFont{\otf@JTn}{hgt}{m}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
+		\DeclareRelationFont{\otf@JYn}{hgt}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
+		\DeclareRelationFont{\otf@JTn}{hgt}{bx}{}{\otf@OTorT1}{\otf@cmorlm@ r}{bx}{}
 	\fi
 	\@ifpackageloaded{jisx0213}{\relax}{\def\mcdefault{hmc}\def\gtdefault{hgt}}
 	\if@jfam@used
@@ -327,8 +334,8 @@
 	\if@deluxe
 		\DeclareKanjiFamily{\otf@JYn}{rubyg}{}
 		\DeclareKanjiFamily{\otf@JTn}{rubyg}{}
-		\DeclareRelationFont{\otf@JYn}{rubyg}{m}{}{\otf@OTorT1}{cmss}{m}{}
-		\DeclareRelationFont{\otf@JTn}{rubyg}{m}{}{\otf@OTorT1}{cmss}{m}{}
+		\DeclareRelationFont{\otf@JYn}{rubyg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
+		\DeclareRelationFont{\otf@JTn}{rubyg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
 		\DeclareRobustCommand\rubyfamily{\edef\reserved@a{\gtdefault}%
 			\edef\reserved@b{\mgdefault}%
 			\ifx\k@family\reserved@a \kanjifamily{rubyg}\else\ifx\k@family\reserved@b
@@ -410,16 +417,16 @@
 	\def\ltdefault{l}
 	\DeclareKanjiFamily{\otf@JYn}{mg}{}
 	\DeclareKanjiFamily{\otf@JTn}{mg}{}
-	\DeclareRelationFont{\otf@JYn}{mg}{m}{}{\otf@OTorT1}{cmss}{m}{}
-	\DeclareRelationFont{\otf@JTn}{mg}{m}{}{\otf@OTorT1}{cmss}{m}{}
+	\DeclareRelationFont{\otf@JYn}{mg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
+	\DeclareRelationFont{\otf@JTn}{mg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
 	\DeclareMathAlphabet{\mathmg}{\otf@JYn}{mg}{m}{n}
 	\DeclareRobustCommand\mgfamily{\not@math@alphabet\mgfamily\mathmg%
 		\kanjifamily\mgdefault\selectfont}
 	\DeclareTextFontCommand{\textmg}{\mgfamily}
 	\DeclareKanjiFamily{\otf@JYn}{rubymg}{}
 	\DeclareKanjiFamily{\otf@JTn}{rubymg}{}
-	\DeclareRelationFont{\otf@JYn}{rubymg}{m}{}{\otf@OTorT1}{cmss}{m}{}
-	\DeclareRelationFont{\otf@JTn}{rubymg}{m}{}{\otf@OTorT1}{cmss}{m}{}
+	\DeclareRelationFont{\otf@JYn}{rubymg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
+	\DeclareRelationFont{\otf@JTn}{rubymg}{m}{}{\otf@OTorT1}{\otf@cmorlm@ ss}{m}{}
 	\DeclareRobustCommand\propshape
 		{\not@math@alphabet\propshape\relax
 		\kanjishape\propdefault\selectfont}


### PR DESCRIPTION
`lmodern` パッケージが読み込まれていたら、和文書体の従属欧文書体をLatin Modernに置き換えたらどうかというPRです。

独り言：ただ…、実用上では、おそらくこれでは不十分で、 `\ltseries`, `\ebseries` を考慮していないですね。場当たり的にやると、下記のように上書きしちゃう手もあるかもです。
{code}
\RequirePackage{lmodern}
\input t1lmr.fd
\input t1lmss.fd
\DeclareFontShape{T1}{lmr}{l}{n}{<->sub*lmr/m/n}{}
\DeclareFontShape{T1}{lmss}{eb}{n}{<->sub*lmss/bx/n}{}

\RequirePackage[deluxe,jis2004]{otf}
\DeclareRobustCommand\ltseries{\not@math@alphabet\ltseries\relax
  \romanseries\ltdefault\kanjiseries\ltdefault\selectfont}
\DeclareRobustCommand\ebseries{\not@math@alphabet\ebseries\relax
  \romanseries\ebdefault\kanjiseries\ebdefault\selectfont}
\DeclareRobustCommand\mgfamily{\not@math@alphabet\mgfamily\mathmg\relax
  \romanfamily\sfdefault\kanjifamily\mgdefault\selectfont}
\DeclareRobustCommand\textmc[1]{%
    \relax\ifmmode \expandafter\nfss@text \fi{\mcfamily #1}}
\DeclareRobustCommand\textgt[1]{%
    \relax\ifmmode \expandafter\nfss@text \fi{\gtfamily\sffamily #1}}
\DeclareTextFontCommand{\textlt}{\mcfamily\ltseries}%%<- otfパッケージ利用のみ前提で、mc以外を考慮していない
\DeclareTextFontCommand{\texteb}{\gtfamily\sffamily\ebseries}%%<- otfパッケージ利用のみ前提で、gt以外を考慮していない
\DeclareRelationFont{\otf@JYn}{hmc}{l}{}{\otf@OTorT1}{lmr}{l}{}
\DeclareRelationFont{\otf@JTn}{hmc}{l}{}{\otf@OTorT1}{lmr}{l}{}
\DeclareRelationFont{\otf@JYn}{hmc}{m}{}{\otf@OTorT1}{lmr}{m}{}
\DeclareRelationFont{\otf@JTn}{hmc}{m}{}{\otf@OTorT1}{lmr}{m}{}
\DeclareRelationFont{\otf@JYn}{hmc}{bx}{}{\otf@OTorT1}{lmr}{bx}{}
\DeclareRelationFont{\otf@JTn}{hmc}{bx}{}{\otf@OTorT1}{lmr}{bx}{}
\DeclareRelationFont{\otf@JYn}{hgt}{m}{}{\otf@OTorT1}{lmss}{m}{}
\DeclareRelationFont{\otf@JTn}{hgt}{m}{}{\otf@OTorT1}{lmss}{m}{}
\DeclareRelationFont{\otf@JYn}{hgt}{bx}{}{\otf@OTorT1}{lmss}{bx}{}
\DeclareRelationFont{\otf@JTn}{hgt}{bx}{}{\otf@OTorT1}{lmss}{bx}{}
\DeclareRelationFont{\otf@JYn}{hgt}{eb}{}{\otf@OTorT1}{lmss}{bx}{}
\DeclareRelationFont{\otf@JTn}{hgt}{eb}{}{\otf@OTorT1}{lmss}{bx}{}
\DeclareRelationFont{\otf@JYn}{mg}{m}{}{\otf@OTorT1}{lmss}{m}{}
\DeclareRelationFont{\otf@JTn}{mg}{m}{}{\otf@OTorT1}{lmss}{m}{}
{/code}
